### PR TITLE
make model_type for gazebo and ign the same

### DIFF
--- a/traffic_editor/gui/crowd_sim/crowd_sim_impl.cpp
+++ b/traffic_editor/gui/crowd_sim/crowd_sim_impl.cpp
@@ -57,13 +57,8 @@ void CrowdSimImplementation::_initialize_model_type()
     _model_types[0] = ModelType("human", "walk");
   auto& default_type = _model_types.at(0);
   default_type.set_animation_speed(0.2);
-  default_type.set_gazebo_conf(
-    "walk.dae",
-    "stand.dae",
-    {0, 0, 0, 0, 0, 0}
-  );
-  default_type.set_ign_conf(
-    "https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor",
+  default_type.set_model_uri("model://MaleVisitorPhone");
+  default_type.set_init_pose(
     {0, 0, 0, 0, 0, 0}
   );
 }

--- a/traffic_editor/gui/crowd_sim/model_type.cpp
+++ b/traffic_editor/gui/crowd_sim/model_type.cpp
@@ -27,8 +27,8 @@ YAML::Node ModelType::to_yaml() const
   model_node["typename"] = get_name();
   model_node["animation"] = get_animation();
   model_node["animation_speed"] = get_animation_speed();
-  model_node["gazebo"] = _gazebo_conf.to_yaml();
-  model_node["ign"] = _ign_conf.to_yaml();
+  model_node["model_uri"] = get_model_uri();
+  model_node["init_pose"] = get_init_pose();
   return model_node;
 }
 
@@ -38,61 +38,13 @@ void ModelType::from_yaml(const YAML::Node& input)
   _name = input["typename"].as<std::string>();
   _animation = input["animation"].as<std::string>();
   _animation_speed = input["animation_speed"].as<double>();
-  _gazebo_conf.from_yaml(input["gazebo"]);
-  _ign_conf.from_yaml(input["ign"]);
-}
-
-//==============================================
-YAML::Node ModelType::GazeboConf::to_yaml() const
-{
-  YAML::Node result = YAML::Node(YAML::NodeType::Map);
-  result.SetStyle(YAML::EmitterStyle::Flow);
-  result["filename"] = filename;
-  result["idle_filename"] = idle_filename;
-  result["pose"] = YAML::Node(YAML::NodeType::Sequence);
-  result["pose"] = initial_pose;
-  return result;
-}
-
-//==============================================
-void ModelType::GazeboConf::from_yaml(const YAML::Node& input)
-{
-  filename = input["filename"].as<std::string>();
-  if (input["idle_filename"])
-    idle_filename = input["idle_filename"].as<std::string>();
-  else
-    idle_filename = "";
-  const YAML::Node& pose_node = input["pose"];
+  _model_uri = input["model_uri"].as<std::string>();
+  const YAML::Node& pose_node = input["init_pose"];
   size_t i = 0;
   for (YAML::const_iterator it = pose_node.begin();
-    it != pose_node.end() && i < initial_pose.size();
+    it != pose_node.end() && i < _init_pose.size();
     it++)
   {
-    initial_pose[i++] = (*it).as<double>();
-  }
-}
-
-//==============================================
-YAML::Node ModelType::IgnConf::to_yaml() const
-{
-  YAML::Node result = YAML::Node(YAML::NodeType::Map);
-  result.SetStyle(YAML::EmitterStyle::Flow);
-  result["model_file_path"] = filename;
-  result["pose"] = YAML::Node(YAML::NodeType::Sequence);
-  result["pose"] = initial_pose;
-  return result;
-}
-
-//==============================================
-void ModelType::IgnConf::from_yaml(const YAML::Node& input)
-{
-  filename = input["model_file_path"].as<std::string>();
-  const YAML::Node& pose_node = input["pose"];
-  size_t i = 0;
-  for (YAML::const_iterator it = pose_node.begin();
-    it != pose_node.end() && i < initial_pose.size();
-    it++)
-  {
-    initial_pose[i++] = (*it).as<double>();
+    _init_pose[i++] = (*it).as<double>();
   }
 }

--- a/traffic_editor/gui/crowd_sim/model_type_table.cpp
+++ b/traffic_editor/gui/crowd_sim/model_type_table.cpp
@@ -25,8 +25,7 @@ std::shared_ptr<ModelTypeTab> ModelTypeTab::init_and_make(
 {
   const QStringList labels =
   {"name", "animation", "anim_speed",
-    "gazebo_model", "gazebo_idle", "x", "y", "z", "pitch", "roll", "yaw",
-    "ign_model", "x", "y", "z", "pitch", "roll", "yaw",
+    "model_uri", "x", "y", "z", "pitch", "roll", "yaw",
     ""};
 
   auto model_type_tab = std::make_shared<ModelTypeTab>(crowd_sim_impl, labels);
@@ -35,7 +34,7 @@ std::shared_ptr<ModelTypeTab> ModelTypeTab::init_and_make(
     printf("Failed to create model_type table! Exiting");
     return nullptr;
   }
-  model_type_tab->setMinimumSize(1600, 400);
+  model_type_tab->setMinimumSize(1200, 400);
   return model_type_tab;
 }
 
@@ -50,56 +49,32 @@ void ModelTypeTab::list_item_in_cache()
       new QTableWidgetItem(QString::fromStdString(
         current_model_type.get_name() )));
     setItem(i, 1,
-      new QTableWidgetItem(QString::fromStdString(current_model_type.
-      get_animation() )));
+      new QTableWidgetItem(QString::fromStdString(
+        current_model_type.get_animation() )));
     setItem(i, 2,
-      new QTableWidgetItem(QString::number(current_model_type.
-      get_animation_speed() )));
+      new QTableWidgetItem(QString::number(
+        current_model_type.get_animation_speed() )));
     setItem(i, 3,
-      new QTableWidgetItem(QString::fromStdString(current_model_type.
-      get_gazebo_conf().filename)));
+      new QTableWidgetItem(QString::fromStdString(
+        current_model_type.get_model_uri() )));
     setItem(i, 4,
-      new QTableWidgetItem(QString::fromStdString(current_model_type.
-      get_gazebo_conf().idle_filename)));
+      new QTableWidgetItem(QString::number(
+        current_model_type.get_init_pose()[0])));
     setItem(i, 5,
-      new QTableWidgetItem(QString::number(current_model_type.get_gazebo_conf().
-      initial_pose[0])));
+      new QTableWidgetItem(QString::number(
+        current_model_type.get_init_pose()[1])));
     setItem(i, 6,
-      new QTableWidgetItem(QString::number(current_model_type.get_gazebo_conf().
-      initial_pose[1])));
+      new QTableWidgetItem(QString::number(
+        current_model_type.get_init_pose()[2])));
     setItem(i, 7,
-      new QTableWidgetItem(QString::number(current_model_type.get_gazebo_conf().
-      initial_pose[2])));
+      new QTableWidgetItem(QString::number(
+        current_model_type.get_init_pose()[3])));
     setItem(i, 8,
-      new QTableWidgetItem(QString::number(current_model_type.get_gazebo_conf().
-      initial_pose[3])));
+      new QTableWidgetItem(QString::number(
+        current_model_type.get_init_pose()[4])));
     setItem(i, 9,
-      new QTableWidgetItem(QString::number(current_model_type.get_gazebo_conf().
-      initial_pose[4])));
-    setItem(i, 10,
-      new QTableWidgetItem(QString::number(current_model_type.get_gazebo_conf().
-      initial_pose[5])));
-    setItem(i, 11,
-      new QTableWidgetItem(QString::fromStdString(current_model_type.
-      get_ign_conf().filename)));
-    setItem(i, 12,
-      new QTableWidgetItem(QString::number(current_model_type.get_ign_conf().
-      initial_pose[0])));
-    setItem(i, 13,
-      new QTableWidgetItem(QString::number(current_model_type.get_ign_conf().
-      initial_pose[1])));
-    setItem(i, 14,
-      new QTableWidgetItem(QString::number(current_model_type.get_ign_conf().
-      initial_pose[2])));
-    setItem(i, 15,
-      new QTableWidgetItem(QString::number(current_model_type.get_ign_conf().
-      initial_pose[3])));
-    setItem(i, 16,
-      new QTableWidgetItem(QString::number(current_model_type.get_ign_conf().
-      initial_pose[4])));
-    setItem(i, 17,
-      new QTableWidgetItem(QString::number(current_model_type.get_ign_conf().
-      initial_pose[5])));
+      new QTableWidgetItem(QString::number(
+        current_model_type.get_init_pose()[5])));
   }
 }
 
@@ -132,33 +107,22 @@ void ModelTypeTab::save()
       item(i, 1)->text().toStdString() );
     current_model_type.set_animation_speed(
       item(i, 2)->text().toDouble(&OK_status) );
+    current_model_type.set_model_uri(
+      item(i, 3)->text().toStdString() );
 
-    std::string filename = item(i, 3)->text().toStdString();
-    std::string idle_filename = item(i, 4)->text().toStdString();
-    std::vector<double> initial_pose = {
+    std::vector<double> init_pose = {
+      item(i, 4)->text().toDouble(&OK_status),
       item(i, 5)->text().toDouble(&OK_status),
       item(i, 6)->text().toDouble(&OK_status),
       item(i, 7)->text().toDouble(&OK_status),
       item(i, 8)->text().toDouble(&OK_status),
-      item(i, 9)->text().toDouble(&OK_status),
-      item(i, 10)->text().toDouble(&OK_status)
+      item(i, 9)->text().toDouble(&OK_status)
     };
-    current_model_type.set_gazebo_conf(
-      filename,
-      idle_filename,
-      initial_pose);
+    current_model_type.set_init_pose(
+      init_pose);
 
-    filename = item(i, 11)->text().toStdString();
-    initial_pose = {
-      item(i, 12)->text().toDouble(&OK_status),
-      item(i, 13)->text().toDouble(&OK_status),
-      item(i, 14)->text().toDouble(&OK_status),
-      item(i, 15)->text().toDouble(&OK_status),
-      item(i, 16)->text().toDouble(&OK_status),
-      item(i, 17)->text().toDouble(&OK_status)
-    };
-    current_model_type.set_ign_conf(filename, initial_pose);
-
+    if (!current_model_type.is_valid())
+      continue;
     tmp_cache.push_back(current_model_type);
   }
   _cache = tmp_cache;

--- a/traffic_editor/gui/crowd_sim/state_table.cpp
+++ b/traffic_editor/gui/crowd_sim/state_table.cpp
@@ -102,6 +102,9 @@ void StatesTab::save()
   //row 0 is not allowed to be changed
   tmp_cache.emplace_back("external_static");
 
+  //check duplicate names
+  std::set<std::string> saved_names;
+
   for (auto i = 1; i < rows_count - 1; i++)
   {
     auto name_item = item(i, 0)->text().toStdString();
@@ -117,11 +120,20 @@ void StatesTab::save()
       static_cast<QComboBox*>(cellWidget(i,
       3))->currentText().toInt(&OK_status);
 
+    if (saved_names.find(name_item) != saved_names.end())
+    {
+      std::cout << "Defined duplicate state name for [" <<
+        name_item << "]. Skip saving this state." <<
+        std::endl;
+      continue;
+    }
+
     tmp_cache.emplace_back(name_item);
     auto& cur_it = tmp_cache.back();
     cur_it.set_final_state(final_item == "1");
     cur_it.set_navmesh_file_name(navmesh_file_name);
     cur_it.set_goal_set_id(static_cast<size_t>(goal_set_id));
+    saved_names.insert(name_item);
   }
 
   _cache = tmp_cache;

--- a/traffic_editor/include/traffic_editor/crowd_sim/model_type.h
+++ b/traffic_editor/include/traffic_editor/crowd_sim/model_type.h
@@ -29,80 +29,44 @@ namespace crowd_sim {
 class ModelType
 {
 public:
-  struct GazeboConf
-  {
-    std::string filename;
-    std::string idle_filename;
-    std::vector<double> initial_pose;
-
-    GazeboConf(
-      std::string file = "",
-      std::string idle_file = "",
-      std::vector<double> pose = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0})
-    : filename(file),
-      idle_filename(idle_file),
-      initial_pose(pose)
-    {}
-
-    YAML::Node to_yaml() const;
-    void from_yaml(const YAML::Node& input);
-  };
-
-  struct IgnConf
-  {
-    std::string filename;
-    std::vector<double> initial_pose;
-    IgnConf(
-      std::string file = "",
-      std::vector<double> pose = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0})
-    : filename(file),
-      initial_pose(pose)
-    {}
-
-    YAML::Node to_yaml() const;
-    void from_yaml(const YAML::Node& input);
-  };
-
-public:
   ModelType(std::string type_name, std::string animation_name)
   : _name(type_name),
     _animation(animation_name),
     _animation_speed(0.2),
-    _gazebo_conf(),
-    _ign_conf()
+    _model_uri(""),
+    _init_pose({0.0, 0.0, 0.0, 0.0, 0.0, 0.0})
   {}
 
   ModelType(const YAML::Node& input)
   : _name("N.A"),
     _animation("N.A"),
     _animation_speed(0.2),
-    _gazebo_conf(),
-    _ign_conf()
+    _model_uri(""),
+    _init_pose({0.0, 0.0, 0.0, 0.0, 0.0, 0.0})
   {
     from_yaml(input);
   }
 
-  std::string get_name() const {return _name;}
-  std::string get_animation() const {return _animation;}
-  double get_animation_speed() const {return _animation_speed;}
-  GazeboConf get_gazebo_conf() const {return _gazebo_conf;}
-  IgnConf get_ign_conf() const {return _ign_conf;}
+  std::string get_name() const { return _name; }
+  std::string get_animation() const { return _animation; }
+  double get_animation_speed() const { return _animation_speed; }
+  std::string get_model_uri() const { return _model_uri; }
+  std::vector<double> get_init_pose() const { return _init_pose; }
 
-  void set_name(std::string type_name) { _name = type_name; }
-  void set_animation(std::string animation_name)
+  void set_name(const std::string& type_name) { _name = type_name; }
+  void set_animation(const std::string& animation_name)
   {
     _animation = animation_name;
   }
   void set_animation_speed(double speed) { _animation_speed = speed; }
-  void set_gazebo_conf(std::string file, std::string idle_file,
-    std::vector<double> pose)
-  {
-    _gazebo_conf = GazeboConf(file, idle_file, pose);
+  void set_model_uri(const std::string& model_uri) { _model_uri = model_uri; }
+  void set_init_pose(const std::vector<double>& init_pose) 
+  { 
+    _init_pose = init_pose; 
   }
-  void set_ign_conf(std::string file, std::vector<double> pose)
-  {
-    _ign_conf = IgnConf(file, pose);
-  }
+
+  // check model_uri is "model://"
+  bool is_valid() { return _model_uri.size() > 8; }
 
   YAML::Node to_yaml() const;
   void from_yaml(const YAML::Node& input);
@@ -110,8 +74,8 @@ public:
 private:
   std::string _name, _animation;
   double _animation_speed;
-  GazeboConf _gazebo_conf;
-  IgnConf _ign_conf;
+  std::string _model_uri;
+  std::vector<double> _init_pose;
 };
 
 } //namespace crowd_sim


### PR DESCRIPTION
in the last version, we use gazebo 9, which requires the `.dae` file to spawn actors in gazebo, while ign only requires a `model:://` uri to spawn actors. As a result, there are two different ModelType implemented for gazebo and ign.

In gazebo 11, we can just pass `model://` uri to gazebo 11 to spawn actors. So we reduce the unnecessary redundant code. 
In this version, no matter gazebo and ign, only model uri will be passed to the crowd simulation plugin. 